### PR TITLE
Fix broken links to RadixSet/RadixMap in docs.rs

### DIFF
--- a/src/key.rs
+++ b/src/key.rs
@@ -39,8 +39,8 @@ impl<T: KeyComponent> Key for [T] {
 ///
 /// These keys should be equivalent to slices of `T: Ord + Eq + Clone`.
 ///
-/// [`RadixSet`]: struct.RadixSet.html
-/// [`RadixMap`]: struct.RadixMap.html
+/// [`RadixSet`]: set/struct.RadixSet.html
+/// [`RadixMap`]: map/struct.RadixMap.html
 pub trait ExtensibleKey: ToOwned {
     /// A single component of the key. Note that it should be `Ord + Eq + Clone`.
     type Component: KeyComponent;

--- a/src/set.rs
+++ b/src/set.rs
@@ -10,7 +10,7 @@ use key::Key;
 
 /// A set based on a [Radix tree](https://en.wikipedia.org/wiki/Radix_tree).
 ///
-/// See [`RadixMap`](struct.RadixMap.html) for an in-depth explanation of the workings of this
+/// See [`RadixMap`](../map/struct.RadixMap.html) for an in-depth explanation of the workings of this
 /// struct, as it's simply a wrapper around `RadixMap<K, ()>`.
 pub struct RadixSet<K: Key + ?Sized> {
     map: RadixMap<K, ()>,


### PR DESCRIPTION
Links referencing these structs weren't absolute, resulting in dead links on
docs.rs. I generated the docs locally and they're working properly.

I also checked and found another dead link (also fixed).

@maxbla Nice catch! I'll merge this & bump the version on crates.io

Fixes #1